### PR TITLE
changed toArray to attributesToArray

### DIFF
--- a/src/JsonWrapper.php
+++ b/src/JsonWrapper.php
@@ -135,7 +135,7 @@ class JsonWrapper extends Field
 
         }
 
-        $model->setAttribute($this->attribute, $clone->toArray());
+        $model->setAttribute($this->attribute, $clone->attributesToArray());
 
         $callbacks[] = parent::fill($request, $model);
 


### PR DESCRIPTION
While I was trying to add a JsonWrapper to fully loaded Resource with multiple relations I stumbled upon some errors.

Firstly i noticed the #7 error. I got around this error (I guess) by removing the column and adding the column again. Don't know if this fixed the error or the edit of this PR.

Than I got to the point where the array error was gone and got a new weird error. I have one JsonWrapper with one Boolean field named show-movie. But what was saved within my column was the `show-movie` field with 2 relations of my resource. One of them was null and the other one was a complete `toArray` result of the model.

So I searched the code and found where the relations are added to the column value. I changed one method from toArray to attributesToArray on the cloned model and this fixed my issue.

I Don't know if this breaks anything else.

Hope I helped :D.


