### PR TITLE
changed getOriginal to getRawOriginal

### DIFF
--- a/src/JsonWrapper.php
+++ b/src/JsonWrapper.php
@@ -101,7 +101,7 @@ class JsonWrapper extends Field
 
         if ($model->exists) {
 
-            $originalValues = json_decode($model->getOriginal($this->attribute), true) ?? [];
+            $originalValues = json_decode($model->getRawOriginal($this->attribute), true) ?? [];
 
             $clone->setRawAttributes(
                 collect($originalValues)->only($this->fields->map->attribute->filter())->toArray()


### PR DESCRIPTION
fixes the #7 bug.

getOriginal returns the casted value since an update.

getRawOriginal was added to get the uncasted value.