### PR TITLE
Enable help text for child fields

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -15,6 +15,7 @@
                     :via-resource="viaResource"
                     :via-resource-id="viaResourceId"
                     :via-relationship="viaRelationship"
+                    :show-help-text="childField.helpText != null"
             />
 
         </div>


### PR DESCRIPTION
Small change that will allow child fields of a JsonWrapper field to show correctly.